### PR TITLE
Added an action to mark issues as stale.

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "STALE: This issue has been open for 30 days with no activity."
+          close-issue-message: "CLOSED: This issue has been inactive for 14 days since being marked as STALE."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added an action to automatically run once a day at 1:30 and will mark untouched issues as stale after 30 days, and closed them 14 days after that if they haven't been touched